### PR TITLE
Sds/progress bar fix

### DIFF
--- a/src/assets/js/pomadoro.js
+++ b/src/assets/js/pomadoro.js
@@ -161,9 +161,10 @@ function timer(time, pomodoro) {
         var time = moment(duration._milliseconds).format('mm:ss')
         $('#current-time').text(time)
       }
-      if(duration._milliseconds === 0) {
+      if(duration._milliseconds < 0) {
         notify()
         stopTimer(countdown)
+        $('#current-time').text('00:00')
         if(isLongBreak) {
           $('.complete-overlay-div').removeClass('hide')
           isLongBreak = false
@@ -171,7 +172,7 @@ function timer(time, pomodoro) {
         } else {
           $('.continue-overlay-div').removeClass('hide')
         }
-        $('#current-time').text('00:00')
+
       }
     }
   }, 1000)


### PR DESCRIPTION
## Progress Fixes:
- allow timer to hit 0:00 before switching to continue or complete screen (currently was switching over AT 0:00)
- progress bar fill was off by one session